### PR TITLE
Custom channel selection colors

### DIFF
--- a/LazyMadeThemes/null.css
+++ b/LazyMadeThemes/null.css
@@ -1039,7 +1039,6 @@
 .nameDefault-2DI02H,
 .nameMutedText-3Vj4bM,
 .nameMutedVoice-3oxyQZ,
-.nameDefaultText-24KCy5,
 .nameDefaultVoice-3WUH7s,
 .nameLockedText-3pqQcL,
 .nameLockedVoice-26MhB1,
@@ -1389,7 +1388,6 @@ span.mention:hover {
 .theme-dark .description-3_Ncsb,
 .theme-dark .labelDescriptor-1PqHgD,
 .bodyTitle-Y0qMQz,
-.nameDefaultText-24KCy5,
 .nameDefaultVoice-3WUH7s,
 .nameLockedText-3pqQcL,
 .nameLockedVoice-26MhB1,
@@ -1399,6 +1397,11 @@ span.mention:hover {
 .nameDefault-2DI02H,
 .membersGroup-v9BXpm {
     color: var(--text-color) !important;
+}
+
+.nameDefaultText-24KCy5,
+.nameDefaultVoice-3WUH7s {
+    color: var(--selection-color) !important;
 }
 
 .has-more button {

--- a/LazyMadeThemes/null.theme.css
+++ b/LazyMadeThemes/null.theme.css
@@ -15,8 +15,8 @@
     --saturation: (1) + (-102%);
     --lightness: (1) + (-6%);
     --alpha: (1) + (0);
-    --text-color: hsl(343, 38%, 40%);
-    /*text,accent,tooltips*/
+    --text-color: hsl(343, 38%, 40%); /*text,accent,tooltips*/
+    --selection-color: hsl(343, 38%, 40%); /*server channels*/
 }
 
 

--- a/LazyMadeThemes/readme.md
+++ b/LazyMadeThemes/readme.md
@@ -51,6 +51,7 @@ so if it is 50 then final result is for hue in hsla will be 100
     --lightness: (1) + (-13.5%);
     --alpha: (1) + (0);
     --text-color: hsl(292, 15%, 37%);
+    --selection-color: hsl(292, 15%, 37%);
 }
 ```
 ![Imgur](https://i.imgur.com/Sv8Q1IS.png)
@@ -63,6 +64,7 @@ so if it is 50 then final result is for hue in hsla will be 100
     --lightness: (1) + (-6%);
     --alpha: (1) + (0);
     --text-color: hsl(109, 38%, 40%);
+    --selection-color: hsl(109, 38%, 40%);
 }
 ```
 ![Imgur](https://i.imgur.com/nIyJ7Tq.png)
@@ -75,6 +77,7 @@ so if it is 50 then final result is for hue in hsla will be 100
     --lightness: (1) + (17%);
     --alpha: (1) + (-0);
     --text-color: hsl(207, 143%, 36%);
+    --selection-color: hsl(207, 143%, 36%);
 }
 ```
 ![Imgur](https://i.imgur.com/EEGcglI.png)
@@ -87,6 +90,7 @@ so if it is 50 then final result is for hue in hsla will be 100
     --lightness: 1 + -9%;
     --alpha: 1 + 0;
     --text-color: #3e3c3e;
+    --selection-color: #3e3c3e;
     }
 ```
 ![Imgur](https://i.imgur.com/8BgpzK3.png)


### PR DESCRIPTION
I really like the theme, the only gripe I have is that the channel selection colors looked really bad with some accent colors because it'd be hard to see if something was unread or not. So I added support for changing the color of the selection boxes with an option, users can make it the same was the accent color for the same effect or choose on to their own liking.

For example I used the option to make my menu look like:

![selection photo](https://mastacoder.com/shr/1530320779.png)
